### PR TITLE
Don't test write on readonly devices

### DIFF
--- a/lib/MogileFS/Worker/Monitor.pm
+++ b/lib/MogileFS/Worker/Monitor.pm
@@ -173,6 +173,14 @@ sub check_device {
     return if ($self->{last_test_write}{$devid} || 0) + UPDATE_DB_EVERY > $now;
     $self->{last_test_write}{$devid} = $now;
 
+
+    unless ($dev->can_delete_from)
+    {
+      # we should not try to write on readonly devices because it can be mounted as RO that fails storage nginxes etc. actively
+      $self->broadcast_device_readable($devid);
+      debug("dev$devid: used = $used, total = $total, writeable = 0");
+      return;
+    }
     # now we want to check if this device is writeable
 
     # first, create the test-write directory.  this will return


### PR DESCRIPTION
Our volumes can be grown until min_free_space will be reached.
We make sometimes these volumes readonly and mount filesystems as readonly too.

This is because file systems like XFS have bad behavior (crashes) and write attempts on nearfull volumes.

So here is a patch to not try to do useless test writes on readonly volumes.

This fix also make administratos happy on procedures of file system repair.

Test writes are evil while file system under repair process. So simply check device as readonly and have fun!
