### PR TITLE
Fix for monitor job timeouts.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+   * Fixed issue where too many devices being active could cause the monitor job
+     to be timed out by the watchdog.
+
 2011-11-14: Release version 2.55
 
    * fixed sources in replication are now a suggestion (dormando <dormando@rydia.net>)

--- a/lib/MogileFS/Worker/Monitor.pm
+++ b/lib/MogileFS/Worker/Monitor.pm
@@ -76,6 +76,8 @@ sub usage_refresh {
         $cur_iow->{$dev->id} = $self->{devutil}->{cur}->{$dev->id};
         next if $self->{skip_host}{$dev->hostid};
         $self->check_device($dev) if $dev->dstate->should_monitor;
+        $self->still_alive; # Ping parent if needed so we don't time out
+                            # given lots of devices.
     }
 
     $self->{devutil}->{prev} = $cur_iow;


### PR DESCRIPTION
This fixes the watchdog repeatedly shooting the monitor job when you have
a lot of devices and things are a little slow.
