### PR TITLE
Add `replicateonly` support

### DIFF
--- a/lib/MogileFS/Device.pm
+++ b/lib/MogileFS/Device.pm
@@ -123,6 +123,10 @@ sub can_read_from {
     return $_[0]->dstate->can_read_from;
 }
 
+sub is_replicateonly {
+    return $_[0]->dstate->is_replicateonly;
+}
+
 # FIXME: Is there a (unrelated to this code) bug where new files aren't tested
 # against the free space limit before being stored or replicated somewhere?
 sub should_get_new_files {

--- a/lib/MogileFS/DeviceState.pm
+++ b/lib/MogileFS/DeviceState.pm
@@ -25,6 +25,12 @@ my $singleton = {
         read => 1,
         monitor => 1,
     }),
+    'replicateonly' => bless({
+        replicateonly => 1,
+        write => 1,
+        monitor => 1,
+        new_files => 1,
+    }),
     'drain' => bless({
         read => 1,
         write => 1,
@@ -42,6 +48,7 @@ sub of_string {
 sub should_drain      { $_[0]->{drain}     }
 sub can_delete_from   { $_[0]->{write}     }
 sub can_read_from     { $_[0]->{read}      }
+sub is_replicateonly  { $_[0]->{replicateonly} }
 sub should_get_new_files { $_[0]->{new_files} }
 sub should_get_repl_files { $_[0]->{new_files} }
 sub should_have_files { ! ($_[0]->{drain} || $_[0]->{dead}) }
@@ -50,7 +57,6 @@ sub should_monitor    { $_[0]->{monitor}   }
 # named inconveniently so it's not taken to mean equalling string
 # "dead"
 sub is_perm_dead      { $_[0]->{dead}   }
-
 sub should_wake_reaper { $_[0]->{dead}   }
 
 sub should_fsck_search_on {

--- a/lib/MogileFS/Store.pm
+++ b/lib/MogileFS/Store.pm
@@ -20,7 +20,8 @@ use List::Util qw(shuffle);
 #     also adds a TEXT 'arg' column to file_to_queue for passing arguments
 # 14: modifies 'device' mb_total, mb_used to INT for devs > 16TB
 # 15: adds checksum table, adds 'hashtype' column to 'class' table
-use constant SCHEMA_VERSION => 15;
+# 16: adds 'replicateonly' device status
+use constant SCHEMA_VERSION => 16;
 
 sub new {
     my ($class) = @_;
@@ -529,6 +530,7 @@ sub setup_database {
     $sto->upgrade_add_device_weight;
     $sto->upgrade_add_device_readonly;
     $sto->upgrade_add_device_drain;
+    $sto->upgrade_add_device_replicateonly;
     $sto->upgrade_add_class_replpolicy;
     $sto->upgrade_modify_server_settings_value;
     $sto->upgrade_add_file_to_queue_arg;

--- a/lib/MogileFS/Store/MySQL.pm
+++ b/lib/MogileFS/Store/MySQL.pm
@@ -386,6 +386,13 @@ sub upgrade_add_device_drain {
     }
 }
 
+sub upgrade_add_device_replicateonly {
+    my $self = shift;
+    unless ($self->column_type("device", "status") =~ /replicateonly/) {
+        $self->dowell("ALTER TABLE device MODIFY COLUMN status ENUM('alive', 'dead', 'down', 'readonly', 'replicateonly', 'drain')");
+    }
+}
+
 sub upgrade_modify_server_settings_value {
     my $self = shift;
     unless ($self->column_type("server_settings", "value") =~ /text/i) {

--- a/lib/MogileFS/Store/Postgres.pm
+++ b/lib/MogileFS/Store/Postgres.pm
@@ -193,7 +193,7 @@ sub TABLE_device {
     hostid      SMALLINT NOT NULL,
 
     status      VARCHAR(8),
-    CHECK       (status IN ('alive','dead','down','readonly','drain')),
+    CHECK       (status IN ('alive','dead','down','readonly','replicateonly','drain')),
     weight      INT DEFAULT 100,
 
     mb_total    INT,
@@ -290,6 +290,14 @@ sub upgrade_add_device_drain {
         $self->dowell("ALTER TABLE device MODIFY COLUMN status VARCHAR(8) CHECK(status IN ('alive', 'dead', 'down', 'readonly','drain'))");
     }
 }
+
+sub upgrade_add_device_replicateonly {
+    my $self = shift;
+    unless ($self->column_constraint("device", "status") =~ /replicateonly/) {
+        $self->dowell("ALTER TABLE device MODIFY COLUMN status VARCHAR(8) CHECK(status IN ('alive', 'dead', 'down', 'readonly','drain','replicateonly'))");
+    }
+}
+
 
 sub upgrade_modify_server_settings_value {
     my $self = shift;

--- a/lib/MogileFS/Store/SQLite.pm
+++ b/lib/MogileFS/Store/SQLite.pm
@@ -134,7 +134,7 @@ sub TABLE_device {
     devid   MEDIUMINT UNSIGNED NOT NULL,
     hostid     MEDIUMINT UNSIGNED NOT NULL,
 
-    status  ENUM('alive','dead','down','readonly','drain'),
+    status  ENUM('alive','dead','down','readonly','replicateonly','drain'),
     weight  MEDIUMINT DEFAULT 100,
 
     mb_total   INT UNSIGNED,

--- a/lib/MogileFS/Worker/Query.pm
+++ b/lib/MogileFS/Worker/Query.pm
@@ -259,9 +259,11 @@ sub cmd_create_open {
 
         last unless $ddev;
         next unless $ddev->not_on_hosts(map { $_->host } @dests);
+        next if $ddev->is_replicateonly;
 
         push @dests, $ddev;
     }
+
     return $self->err_line("no_devices") unless @dests;
 
     my $fidid = eval {


### PR DESCRIPTION
This patch adds what the above said. A storage node tracked as
replicate only won't be able to receive read/get requests from
the tracker.
- Add writeonly device status
- Add writeonly status to database
- Replicate from writeonly devices
- Rename writeonly to replicateonly
- Revert "Replicate from writeonly devices"
- This reverts commit 030f9a651ffb60d73e99d3f21b96552cde52d3f9.
- Conflicts:
  - lib/MogileFS/DeviceState.pm
  - lib/MogileFS/Worker/Replicate.pm
- Don't upload files to replicate only devices.
