### PR TITLE
Delete memcache data when we replicate fids

### DIFF
--- a/lib/MogileFS/DevFID.pm
+++ b/lib/MogileFS/DevFID.pm
@@ -134,6 +134,9 @@ sub add_to_db {
 
     my $sto = Mgd::get_store();
     if ($sto->add_fidid_to_devid($self->{fidid}, $self->{devid})) {
+        if (my $memc = MogileFS::Config->memcache_client) {
+            $memc->delete("mogdevids:$self->{fidid}");
+        }
         return $self->fid->update_devcount(no_lock => $no_lock);
     } else {
         # was already on that device

--- a/lib/MogileFS/Worker/Query.pm
+++ b/lib/MogileFS/Worker/Query.pm
@@ -1058,7 +1058,7 @@ sub cmd_get_paths {
 
     # memcache mappings are as follows:
     #  mogfid:<dmid>:<dkey> -> fidid
-    #  mogdevids:<fidid>    -> \@devids  (and TODO: invalidate when the replication or deletion is run!)
+    #  mogdevids:<fidid>    -> \@devids  (and TODO: invalidate when deletion is run!)
 
     # if you specify 'noverify', that means a correct answer isn't needed and memcache can
     # be used.


### PR DESCRIPTION
Because memcache TTL is now user configurable, data in memcached might
be valid for a long time, and as such invalid paths might be returned.

It would be possible to populate memcache, instead of just removing. But
it might be wasteful when a device is marked as dead, those replicated
fids might not need to be in memcached.

There is still one TODO left. If someone modifies mindevcount and runs
FSCK, then the mappings might become incorrect, but I reasoned that it
would be rather rare.
