### PR TITLE
this prevents some missing symbols because of a dependency cycle

### DIFF
--- a/lib/MogileFS/ReplicationRequest.pm
+++ b/lib/MogileFS/ReplicationRequest.pm
@@ -1,9 +1,9 @@
 package MogileFS::ReplicationRequest;
 use strict;
-use MogileFS::Server;
 require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(rr_upgrade ALL_GOOD TOO_GOOD TEMP_NO_ANSWER);
+require MogileFS::Server;
 
 my $no_answer = bless { temp_fail => 1 };
 sub TEMP_NO_ANSWER () { $no_answer }

--- a/t/29-replreq.t
+++ b/t/29-replreq.t
@@ -1,0 +1,10 @@
+# -*-perl-*-
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { use_ok('MogileFS::ReplicationRequest'); }
+
+done_testing();


### PR DESCRIPTION
this is a minor module dependency fix.

there is a dependency cycle in the form of:

MogileFS::Server -> MogileFS::ReplicationPolicy::MultipleHosts -> MogileFS::ReplicationRequest -> MogileFS::Server

this doesn't cause problems when MogileFS::Server is loaded first, but when MogileFS::ReplicationRequest is loaded first, MogileFS::ReplicationPolicy::MultipleHosts breaks with the following error:

Bareword "ALL_GOOD" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 47.
Bareword "TOO_GOOD" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 65.
Bareword "TOO_GOOD" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 66.
Bareword "ALL_GOOD" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 67.
Bareword "ALL_GOOD" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 68.
Bareword "ALL_GOOD" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 76.
Bareword "TEMP_NO_ANSWER" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 93.
Bareword "TEMP_NO_ANSWER" not allowed while "strict subs" in use at /usr/local/share/perl5/MogileFS/ReplicationPolicy/MultipleHosts.pm line 98.
Compilation failed in require at /usr/local/share/perl5/MogileFS/Server.pm line 63.
BEGIN failed--compilation aborted at /usr/local/share/perl5/MogileFS/Server.pm line 63.
Compilation failed in require at /usr/local/share/perl5/MogileFS/ReplicationRequest.pm line 3.
BEGIN failed--compilation aborted at /usr/local/share/perl5/MogileFS/ReplicationRequest.pm line 3.

an easy command to see this breakage is: 
perl -mMogileFS::ReplicationRequest -e'1;'

I ran into this bug when upgrading the MogileFS database, my first plugin utilized MogileFS::FID, which requires MogileFS::ReplicationRequest before MogileFS::Server has been loaded.
