### PR TITLE
Patch to indicate which mogstored is not listening

### DIFF
--- a/lib/MogileFS/Connection/Mogstored.pm
+++ b/lib/MogileFS/Connection/Mogstored.pm
@@ -18,7 +18,7 @@ sub sock {
     return $self->{sock} if $self->{sock};
     $self->{sock} = IO::Socket::INET->new(PeerAddr => $self->{ip},
                                           PeerPort => $self->{port},
-                                          Timeout  => $timeout);
+                                          Timeout  => $timeout) or die "Could not connect to mogstored on ".$self->{ip}.":".$self->{port};
     $self->{sock}->sockopt(SO_KEEPALIVE, 1);
     return $self->{sock};
 }


### PR DESCRIPTION
I added this patch while upgrading our test environment.  If the connection to a mogstored fails, currently we die with an unhelpful message when setting SO_KEEPALIVE.  This patch adds a die describing what failed.

Kind regards,
Dave Lambley
