### PR TITLE
fix use_dest_devs for rebalance

### DIFF
--- a/lib/MogileFS/Rebalance.pm
+++ b/lib/MogileFS/Rebalance.pm
@@ -309,7 +309,7 @@ sub _choose_dest_devs {
     my @shuffled_devs = List::Util::shuffle(@$filtered_devs);
     return \@shuffled_devs if ($p->{use_dest_devs} eq 'all');
 
-    return splice @shuffled_devs, 0, $p->{use_dest_devs};
+    return [splice @shuffled_devs, 0, $p->{use_dest_devs}];
 }
 
 # Iterate through all possible constraints until we have a final list.


### PR DESCRIPTION
The caller expects an array ref, currently using use_dest_devs will kill
JobMaster with:

Oct 18 09:45:25 storage22 mogilefsd[23263]: crash log: rebalance cannot find suitable destination devices at /usr/local/share/perl/5.10.1/MogileFS/Worker/JobMaster.pm line 233
Oct 18 09:45:26 storage22 mogilefsd[22044]: Child 23263 (job_master) died: 256 (UNEXPECTED)
