### PR TITLE
Fix "skip_devcount" during rebalance

### DIFF
--- a/lib/MogileFS/DevFID.pm
+++ b/lib/MogileFS/DevFID.pm
@@ -170,7 +170,7 @@ sub destroy {
 
     my $sto = Mgd::get_store();
     $sto->remove_fidid_from_devid($self->fidid, $self->devid);
-    $sto->update_devcount($self->fidid);
+    $self->fid->update_devcount(no_lock => 1);
 }
 
 1;


### PR DESCRIPTION
We were updating devcount field even when skip_devcount was true. We
should not use $sto here because we already have FID object and nice
method available for this.
