### PR TITLE
support updating the class to the default class which has an id of 0

### DIFF
--- a/lib/MogileFS/Worker/Query.pm
+++ b/lib/MogileFS/Worker/Query.pm
@@ -489,8 +489,9 @@ sub cmd_updateclass {
     my $key   = $args->{key}        or return $self->err_line("no_key");
     my $class = $args->{class}      or return $self->err_line("no_class");
 
-    my $classid = eval { Mgd::class_factory()->get_by_name($dmid, $class)->id }
+    my $classobj = Mgd::class_factory()->get_by_name($dmid, $class)
         or return $self->err_line('class_not_found');
+    my $classid = $classobj->id;
 
     my $fid = MogileFS::FID->new_from_dmid_and_key($dmid, $key)
         or return $self->err_line('invalid_key');


### PR DESCRIPTION
cmd_updateclass would return a class_not_found error when you are trying to update the class of a file back to the default class which has an id of 0
