### PR TITLE
Reseed the random number generator after forking.

### DIFF
--- a/lib/MogileFS/ProcManager.pm
+++ b/lib/MogileFS/ProcManager.pm
@@ -236,6 +236,9 @@ sub make_new_child {
         return $worker_conn;
     }
 
+    # let children have different random number seeds
+    srand();
+
     # as a child, we want to close these and ignore them
     $_->() foreach @prefork_cleanup;
     close($parents_ipc);


### PR DESCRIPTION
Without reseeding the random number generator after forking, all the children will produce the same random numbers.
