### PR TITLE
Always use next_after from last key

### DIFF
--- a/lib/MogileFS/Worker/Query.pm
+++ b/lib/MogileFS/Worker/Query.pm
@@ -738,8 +738,7 @@ sub cmd_list_keys {
     my $ret = { key_count => 0, next_after => '' };
     foreach my $key (@$keys) {
         $ret->{key_count}++;
-        $ret->{next_after} = $key
-            if $key gt $ret->{next_after};
+        $ret->{next_after} = $key;
         $ret->{"key_$ret->{key_count}"} = $key;
     }
     return $self->ok_line($ret);


### PR DESCRIPTION
The sorting used by the database und perl might be different and
re-checking the order might lead to strange results.
