### PR TITLE
Put multiple devids in create_close

### DIFF
--- a/lib/MogileFS/Worker/Query.pm
+++ b/lib/MogileFS/Worker/Query.pm
@@ -438,6 +438,8 @@ sub cmd_create_close {
         $old_fid->delete;
     }
 
+    my $devcount = 0;
+
     for my $idx (0 .. $#devids) {
         my ($devid, $path) = ($devids[$idx], $paths[$idx]);
         my $dfid = MogileFS::DevFID->new($devid, $fid);
@@ -503,6 +505,7 @@ sub cmd_create_close {
 
         # insert file_on row
         $dfid->add_to_db;
+        $devcount ++;
 
         $checksum->maybe_save($dmid, $trow->{classid}) if $checksum;
 
@@ -512,7 +515,7 @@ sub cmd_create_close {
                                 key     => $key,
                                 length  => $size,
                                 classid => $trow->{classid},
-                                devcount => 1,
+                                devcount => $devcount,
                                 );
     }
 


### PR DESCRIPTION
Still experimental, but it seems like it works.

In `create_close`, instead of `devid=9&path=http://someserver/dev9/1/2/3/123.fid`, you can now specify multiple devs/paths like `devid_1=9&path_1=http://someserver/dev9/1/2/3/123.fid&devid_2=42&path_2=http://someotherserver/dev42/1/2/3/123.fid`, and mogilefsd will write all of those devs to the DB.
