### PR TITLE
Create dirs 000 to prevent mounting accidents

### DIFF
--- a/mogautomount
+++ b/mogautomount
@@ -47,7 +47,7 @@ foreach my $bdev (@bdevs) {
     my ($dev, $devid) = ($1, $2);
     unless (-d "$base") { mkdir $base or die "Failed to mkdir $base: $!"; }
     my $mnt = "$base/dev$devid";
-    unless (-d $mnt) { mkdir $mnt or die "Failed to mkdir $mnt: $!"; }
+    unless (-d $mnt) { mkdir $mnt,0000 or die "Failed to mkdir $mnt: $!"; }
     next if $mounted{$dev};
 
     if ($chmod_mountpoints and ((stat($mnt))[2] & 0777) != 0) {


### PR DESCRIPTION
With the mountpoints set to 000 processes will not be able to write to an un-mounted mount point, in the event that a disk is not mounted.

Without this mogile could start up with an unmounted disk and start writing to the mount point's directory, which in all likelihood is the system drive. If the system drive fills you could be in for a world of hurt.

There is (optional) code later in the script to fix this, but it would affect existing directories which may (for one reason on another) be non-ideal to users. But there is no reason not to create NEW directories this way to protect the majority of use cases.
