### PR TITLE
spit out listen port

### DIFF
--- a/lib/MogileFS/Server.pm
+++ b/lib/MogileFS/Server.pm
@@ -128,6 +128,7 @@ sub run {
                                            Reuse     => 1,
                                            Listen    => 1024 )
             or die "Error creating socket: $@\n";
+	Mgd::log('info', "listening on port: " . $server->sockport());
         $server->sockopt(SO_KEEPALIVE, 1);
         $server->setsockopt(IPPROTO_TCP, TCP_NODELAY, 1);
 


### PR DESCRIPTION
helps when specifying a confport of: '0' and letting the OS decide