### PR TITLE
fix to crash JobMaster when DB lock timed out.

### DIFF
--- a/lib/MogileFS/Store.pm
+++ b/lib/MogileFS/Store.pm
@@ -1723,7 +1723,7 @@ sub grab_queue_chunk {
     my $tries = 3;
     my $work;
 
-    return 0 unless $self->lock_queue($queue);
+    return unless $self->lock_queue($queue);
 
     my $extwhere = shift || '';
     my $fields = 'fid, nexttry, failcount';

--- a/lib/Mogstored/ChildProcess/IOStat.pm
+++ b/lib/Mogstored/ChildProcess/IOStat.pm
@@ -141,7 +141,7 @@ sub mog_sysid_map {
             my $devname = $number_to_name{$original} or next;
 
             # Pull off the new device name with a regex
-            if (my ($newname) = $devname =~ m/^([hs]d\w+)\d+$/) {
+            if (my ($newname) = $devname =~ m/^([hs]d\w+?)\d+$/) {
                 # Skip if we can't map it back to a device number
                 my $newnum = $name_to_number{$newname} or next;
                 $map->{$mogdevid} = $newnum;


### PR DESCRIPTION
On JobMaster,  $sto->grab_files_to_*()  returns scalar 0 when lock_queue() is timeouted.
But it checks for array, then crash JobMaster.
Fix it.